### PR TITLE
Pegged hapi version peer dependency.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "dependencies": {
     "hoek": "2.x.x"
   },
+  "peerDependencies": {
+    "hapi": ">= 8.x.x < 10"
+  },
   "devDependencies": {
     "code": "1.x.x",
     "hapi": "9.x.x",


### PR DESCRIPTION
Until the public API is cleaned up, we can only support Hapi 8 and 9.
