### PR TITLE
Fixed issue with connection._registrations

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -22,17 +22,15 @@ var constructResponse = function (server) {
   var connections = server.connections.map(function (connection) {
     var plugins = {};
 
-    // TODO: Don't use _registrations and instead use a public API
-    // related issue: https://github.com/hapijs/hapi/issues/2777
-    Object.keys(connection._registrations).forEach(function (name) {
-      var registration = connection._registrations[name];
+    Object.keys(connection.registrations).forEach(function (name) {
+      var registration = connection.registrations[name];
 
       plugins[name] = {
         name: name,
         version: registration.version,
         multiple: registration.multiple,
         options: registration.options,
-        attributes: registration.register.attributes
+        attributes: registration.attributes
       };
     });
 


### PR DESCRIPTION
Previous there was an issue raised here:

> TODO: Don't use _registrations and instead use a public API
> related issue: https://github.com/hapijs/hapi/issues/2777

This was fixed and closed.  I was experiencing issues running `http://localhost:8888/setup` as documented
here:  https://github.com/continuationlabs/hapi-setup/issues/28

Switched to using `connection.registrations` and `connection.registration.attributes`
